### PR TITLE
Add filename to ParserException message

### DIFF
--- a/src/ParserException.php
+++ b/src/ParserException.php
@@ -10,6 +10,6 @@ class ParserException extends \Exception {
    * @param string $message
    */
   public function __construct($position, $message) {
-    parent::__construct("Error at {$position->getLineNumber()}:{$position->getColumnNumber()}: $message");
+    parent::__construct("Error at {$position->getLineNumber()}:{$position->getColumnNumber()} in {$position->getFilename()}: $message");
   }
 }


### PR DESCRIPTION
This makes errors go from:

Error at 497:44: expected ; 

to:

Error at 497:44 in /Users/webchick/Sites/8.x/modules/cdn/cdn.basic.farfuture.inc: expected ;

...making for much easier debugging.
